### PR TITLE
Logger, shop search, saved presets, stricter shake-to-delete

### DIFF
--- a/src/app/SceneManager.ts
+++ b/src/app/SceneManager.ts
@@ -14,6 +14,9 @@ import { SoundwaveEmitter } from "../world/soundwave/SoundwaveEmitter.ts";
 export class SceneManager {
     private static _instance: SceneManager | null = null
 
+    /** How many times EngineStore.LastCreatedScene was read (see the getter below). */
+    static lastCreatedSceneAccesses = 0
+
     private readonly canvas
     private readonly engine: B.Engine
     private readonly scene
@@ -56,12 +59,22 @@ export class SceneManager {
             }
         });
 
-        // Detect and prevent usage of EngineStore.LastCreatedScene
-        B.EngineStore.LastCreatedScene
+        // Detect usage of EngineStore.LastCreatedScene (a scene should be passed
+        // to constructors instead). It's mostly hit by the third-party
+        // wam3dgenerator texture/thumbnail loader, which we can't fix upstream and
+        // which reads it many times per render — so we warn ONCE and suppress the
+        // rest to keep the console clean. The running total is kept on
+        // SceneManager.lastCreatedSceneAccesses for debugging.
         const oldLastCreatedScene = Object.getOwnPropertyDescriptor(B.EngineStore, "LastCreatedScene");
         Object.defineProperty(B.EngineStore, "LastCreatedScene", {
             get: function () {
-                console.warn("Use EngineStore.LastCreatedScene is prohibited. Pass a scene to the constructor.")
+                SceneManager.lastCreatedSceneAccesses++
+                if (SceneManager.lastCreatedSceneAccesses === 1) {
+                    console.warn(
+                        "EngineStore.LastCreatedScene was read (a scene should be passed to the constructor). " +
+                        "Usually the wam3dgenerator thumbnail/texture loader; further identical warnings are suppressed."
+                    )
+                }
                 return oldLastCreatedScene?.get?.apply(B.EngineStore) ?? null
             },
         })

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,13 +21,12 @@ import { SessionHUD } from "./ui/pages/SessionHUD.ts";
 import { SessionConnector } from "./network/SessionConnector.ts";
 import { SessionAPIClient } from "./network/SessionAPIClient.ts";
 import * as Y from 'yjs';
+import { installConsoleFilter } from "./utils/logger.ts";
 
-// Filter out spammy wam3dgenerator console logs (memory allocation logs)
-const originalConsoleLog = console.log;
-console.log = function(...args: any[]) {
-    if (args.length === 1 && typeof args[0] === 'number') return;
-    originalConsoleLog.apply(console, args);
-};
+// Level-gated console: console.log/info/debug are quiet by default (level "warn")
+// and also drop the wam3dgenerator memory spam. warn/error always pass. Raise
+// verbosity at runtime with `wamjamLog.setLevel("debug")` in the devtools console.
+installConsoleFilter();
 
 let appStarted = false;
 /**

--- a/src/menus/ShopMenu.ts
+++ b/src/menus/ShopMenu.ts
@@ -1,5 +1,5 @@
 import { Scene } from "@babylonjs/core"
-import { Button, Container, Image, Rectangle, ScrollViewer, StackPanel, TextBlock } from "@babylonjs/gui"
+import { Button, Container, Image, InputText, Rectangle, ScrollViewer, StackPanel, TextBlock, VirtualKeyboard } from "@babylonjs/gui"
 import { Node3dManager } from "../app/Node3dManager"
 import { AbstractMenu } from "./AbstractMenu"
 
@@ -20,7 +20,13 @@ export class ShopMenu extends AbstractMenu {
         this.initLabel("label")
         
         // Use arrow functions to capture 'this'
-        
+
+        // All [kind, factory] entries, populated once the factories load. Used
+        // by the search bar to filter across every category at once.
+        let allEntries: { kind: string; factory: { label: string; tags: string[] } }[] = []
+        // Kinds of the currently selected category, restored when search clears.
+        let categoryKinds: string[] = []
+
         // Item List
         const items = new Container()
 
@@ -30,6 +36,78 @@ export class ShopMenu extends AbstractMenu {
             this.place(list, 0, 0, 100, 100)
             items.addControl(list)
         }
+
+        // ── Search: filter all kinds by label / kind / tag as the user types ──
+        const search = new InputText()
+        search.color = "white"
+        search.background = "rgb(0,0,0,0.6)"
+        search.focusedBackground = "rgb(0,0,0,0.85)"
+        search.placeholderText = "Search instruments…"
+        search.placeholderColor = "#9fb4bd"
+        search.fontSize = 26
+        search.text = ""
+
+        const runSearch = (raw: string) => {
+            const q = raw.trim().toLowerCase()
+            if (!q) { setItems(categoryKinds); return }
+            const matches = allEntries
+                .filter(({ kind, factory }) =>
+                    factory.label?.toLowerCase().includes(q) ||
+                    kind.toLowerCase().includes(q) ||
+                    factory.tags.some(t => t.toLowerCase().includes(q)))
+                .map(e => e.kind)
+            setItems(matches)
+        }
+
+        // Overlay virtual keyboard (VR has no system keyboard for canvas inputs).
+        const keyboard = VirtualKeyboard.CreateDefaultLayout()
+        keyboard.width = "100%"
+        keyboard.connect(search)
+
+        // Keyboard is shown while editing, hidden once the search is "submitted"
+        // (Enter or the Done button) so the results fill the panel. Tapping the
+        // field again brings it back. `kbDismissed` lets a non-empty query keep
+        // the keyboard hidden after submit, while still guarding against a
+        // virtual key-press momentarily blurring the field mid-typing.
+        let searchFocused = false
+        let kbDismissed = false
+        const kbRow = new Rectangle()
+        kbRow.background = "rgb(8,12,16,0.96)"
+        kbRow.thickness = 0
+        kbRow.isVisible = false
+        const updateKbVisible = () => {
+            kbRow.isVisible = (searchFocused || search.text.length > 0) && !kbDismissed
+        }
+        const dismissKeyboard = () => { kbDismissed = true; updateKbVisible() }
+
+        search.onFocusObservable.add(() => { searchFocused = true; kbDismissed = false; updateKbVisible() })
+        search.onBlurObservable.add(() => { searchFocused = false; updateKbVisible() })
+        // Tapping the field re-opens the keyboard even if it was dismissed.
+        search.onPointerDownObservable.add(() => { kbDismissed = false; updateKbVisible() })
+        // Enter (hardware keyboard / desktop) submits → hide keyboard, keep query.
+        search.onKeyboardEventProcessedObservable.add((evt) => {
+            if (evt.key === "Enter") dismissKeyboard()
+        })
+
+        // Debounce the actual filtering so fast typing doesn't rebuild the grid
+        // (and lazily render thumbnails) on every keystroke.
+        let searchTimer: ReturnType<typeof setTimeout> | undefined
+        search.onTextChangedObservable.add(() => {
+            updateKbVisible()
+            clearTimeout(searchTimer)
+            searchTimer = setTimeout(() => runSearch(search.text), 140)
+        })
+
+        // Done: hide the keyboard without clearing the query (VR has no Enter key).
+        const doneBtn = Button.CreateSimpleButton("search_done", "Done")
+        doneBtn.color = "white"
+        doneBtn.background = "rgb(20,70,40,0.7)"
+        doneBtn.onPointerUpObservable.add(() => dismissKeyboard())
+
+        const clearBtn = Button.CreateSimpleButton("search_clear", "✕")
+        clearBtn.color = "white"
+        clearBtn.background = "rgb(90,20,20,0.7)"
+        clearBtn.onPointerUpObservable.add(() => { search.text = "" })
 
 
         // Sub menu
@@ -46,11 +124,13 @@ export class ShopMenu extends AbstractMenu {
                     selected: label === selection,
                     action: () => {
                         setSubMenu(label, submenus)
+                        categoryKinds = kinds
+                        if (search.text) search.text = ""   // leave search mode
                         setItems(kinds)
                     }
                 }))
             )
-            if (options.length === 1) setItems(options[0][1])
+            if (options.length === 1) { categoryKinds = options[0][1]; setItems(options[0][1]) }
             submenu.addControl(buttons)
             buttons.horizontalAlignment = StackPanel.HORIZONTAL_ALIGNMENT_CENTER
             buttons.height = "100%"
@@ -82,12 +162,25 @@ export class ShopMenu extends AbstractMenu {
         // Clipboard
         const clipboard = this.createClipboard()
 
+        // ── Layout ─────────────────────────────────────────────────────────────
+        // Search row (input + clear), category bar, item body, then the keyboard
+        // as an overlay over the lower body (only visible while searching).
+        const searchRow = this.rect()
+        this.place(searchRow, 0, 0, 100, 9)
+        this.texture.addControl(searchRow)
+        searchRow.addControl(search)
+        this.place(search, 1, 0, 72, 100)
+        searchRow.addControl(doneBtn)
+        this.place(doneBtn, 74, 0, 12, 100)
+        searchRow.addControl(clearBtn)
+        this.place(clearBtn, 87, 0, 12, 100)
+
         const topbar = this.rect()
-        this.place(topbar, 0, 0, 100, 15)
+        this.place(topbar, 0, 9, 100, 14)
         this.texture.addControl(topbar)
 
         const body = this.rect()
-        this.place(body, 0, 15, 100, 85)
+        this.place(body, 0, 23, 100, 77)
         this.texture.addControl(body)
 
         body.addControl(items)
@@ -102,6 +195,12 @@ export class ShopMenu extends AbstractMenu {
         topbar.addControl(submenu)
         this.place(submenu, 0, 50, 100, 50)
 
+        // Keyboard overlay — added last so it renders on top of the body.
+        this.texture.addControl(kbRow)
+        this.place(kbRow, 0, 52, 100, 48)
+        kbRow.addControl(keyboard)
+        this.place(keyboard, 1, 2, 98, 96)
+
             // Init menu
             ; (async () => {
                 const builder = Node3dManager.getInstance().builder
@@ -112,6 +211,8 @@ export class ShopMenu extends AbstractMenu {
                     else return [kind, factory] as const
                 })))
                     .filter(it => it != null)
+
+                allEntries = factories.map(([kind, factory]) => ({ kind, factory }))
 
                 const menus = {
                     Video: {

--- a/src/node3d/instance/N3DConnectionInstance.ts
+++ b/src/node3d/instance/N3DConnectionInstance.ts
@@ -5,6 +5,7 @@ import { Node3DInstance } from "./Node3DInstance"
 import { SyncSerializable } from "../../network/sync/SyncSerializable"
 import { Doc } from "yjs"
 import { MeshUtils } from "../tools"
+import { ShakeBehavior } from "../../behaviours/ShakeBehavior"
 import { SceneManager } from "../../app/SceneManager"
 import { MenuSystem } from "../../app"
 
@@ -16,6 +17,7 @@ export class N3DConnectionInstance{
     private static readonly DEBUG_LOG = false;
 
     private _tube
+    private shake
     private arrow?: AbstractMesh
     public on_dispose = ()=>{}
 
@@ -33,8 +35,26 @@ export class N3DConnectionInstance{
 
         SceneManager.getInstance().getShadowGenerator().addShadowCaster(this._tube, false)
 
-        // (Shake-to-delete removed — connections are deleted from a node's
-        //  delete menu: "Delete all connections" / "Delete a specific connection".)
+        // Shake-to-delete a connection. Made stricter (on request) so a cable is
+        // never removed by accident: a stronger shake is required (threshold 5,
+        // was 3) and it must be sustained much longer (counter > 24, was 10).
+        // Deliberate deletion is still available from a node's delete menu.
+        this.shake = new ShakeBehavior()
+        this.shake.shake_threshold = 5
+        this._tube.addBehavior(this.shake)
+        this.shake.on_shake = (power, counter) => {
+            this._tube.visibility = Math.max(0, 1 - power / 12)
+            if(counter>24) connections.remove(this)
+        }
+        this.shake.on_stop = (_, __) => {
+            this._tube.visibility = .8
+        }
+        this.shake.on_pick = () => {
+            this._tube.visibility = .8
+        }
+        this.shake.on_drop = () => {
+            this._tube.visibility = 1
+        }
     }
 
     // Public API

--- a/src/node3d/instance/Node3DInstance.ts
+++ b/src/node3d/instance/Node3DInstance.ts
@@ -22,7 +22,7 @@ import { Doc } from "yjs";
 import { Synchronized } from "../../network/sync/Synchronized";
 import { N3DHighlighter } from "./utils/N3DHighlighter";
 import { N3DShared } from "./N3DShared";
-import { AutomationN3DConnectable } from "../tools";
+import { AutomationN3DConnectable, MeshUtils } from "../tools";
 import { NetworkManager } from "../../network/NetworkManager.ts";
 import { N3DButtonInstance } from "./N3DButtonInstance.ts";
 import { SceneManager } from "../../app/SceneManager.ts";
@@ -269,8 +269,78 @@ export class Node3DInstance implements Synchronized {
 
         this.bounding_box = new BoundingBox(this.bounding_mesh)
 
-        // (Shake-to-delete removed — deletion is now handled by the per-node
-        //  delete button / menu created below.)
+
+        // Shake-to-delete — detection based on the REAL movement of the held box
+        // (HoldableBehaviour observables), not the pointer ray: ShakeBehavior
+        // listened to pointer.onMove, a path that doesn't fire in VR while
+        // FullHoldBehaviour holds the box. If dragging works, this works.
+        //
+        // DELIBERATELY HARD TO TRIGGER (made stricter on request) so an item is
+        // never deleted by accident while repositioning it:
+        //   • a swing only counts if it exceeds SWING_MIN (big gestures only),
+        //   • REVERSALS_TO_DELETE direction reversals are required,
+        //   • any pause > RESET_MS between two reversals resets the counter →
+        //     a slow / hesitant move never accumulates anything.
+        // Progressive feedback: colour white→red + a percentage message.
+        const SWING_MIN = 0.13            // m : minimum amplitude of a real swing (was 0.07)
+        const REVERSALS_TO_DELETE = 18    // ≈ 9 sustained back-and-forths (was 10)
+        const RESET_MS = 550              // max pause between two reversals (was 700)
+
+        const box = this.bounding_box.boundingBox
+        const holdable = this.bounding_box.holdable
+        const lastPos = new Vector3()
+        const delta = new Vector3()
+        const lastDelta = new Vector3()
+        let swingDist = 0
+        let reversals = 0
+        let lastReversalAt = 0
+        let deleting = false
+
+        const resetShakeFeedback = () => {
+            reversals = 0
+            swingDist = 0
+            if (!box.isDisposed()) MeshUtils.setColor(box, Color3.White().toColor4())
+        }
+
+        holdable.onGrabObservable.add(() => {
+            lastPos.copyFrom(box.absolutePosition)
+            lastDelta.setAll(0)
+            resetShakeFeedback()
+        })
+
+        holdable.onMoveObservable.add(() => {
+            if (this.disposed || deleting || box.isDisposed()) return
+            box.absolutePosition.subtractToRef(lastPos, delta)
+            if (delta.length() < 0.003) return   // tracking noise
+            const now = performance.now()
+            if (reversals > 0 && now - lastReversalAt > RESET_MS) resetShakeFeedback()
+            if (Vector3.Dot(delta, lastDelta) < 0) {
+                // Direction reversal: only counts if the swing was a real one
+                if (swingDist >= SWING_MIN) {
+                    reversals++
+                    lastReversalAt = now
+                    const progress = reversals / REVERSALS_TO_DELETE
+                    if (reversals >= REVERSALS_TO_DELETE) {
+                        deleting = true
+                        MenuSystem.getInstance().showMessage("Instrument deleted")
+                        NetworkManager.getInstance().node3d.nodes.remove(this)
+                        return
+                    }
+                    MeshUtils.setColor(box, Color3.Lerp(Color3.White(), Color3.Red(), progress).toColor4())
+                    MenuSystem.getInstance().showMessage(`Shake to delete… ${Math.round(progress * 100)} %`)
+                }
+                swingDist = 0
+            } else {
+                swingDist += delta.length()
+            }
+            lastDelta.copyFrom(delta)
+            lastPos.copyFrom(box.absolutePosition)
+        })
+
+        holdable.onReleaseObservable.add(() => {
+            if (!this.disposed && !deleting) resetShakeFeedback()
+        })
+
 
         // On position change
         this.set_state("position")

--- a/src/node3d/subs/ai/AIComposerN3D.ts
+++ b/src/node3d/subs/ai/AIComposerN3D.ts
@@ -483,7 +483,7 @@ export class AIComposerN3D implements Node3D {
                 { swatch: "⚪", name: "Small knobs (bottom)", role: "Tempo (× host tempo), Velocity, Horizon (buffer latency)" },
                 { swatch: "💗", name: "Glowing core", role: "Play/Stop; color = state; pulses on each note; follows the host transport" },
                 { swatch: "🟢", name: "Green sphere (side)", role: "MIDI output — wire to a synth (Pro54…)" },
-                { swatch: "✋", name: "Chassis", role: "Two-handed grab = resize; top-right bin button = delete" },
+                { swatch: "✋", name: "Chassis", role: "Two-handed grab = resize; bin button or vigorous shake = delete" },
             ],
             presets: gui.factory.presets,
             defaultPreset: gui.factory.defaultPreset,

--- a/src/node3d/subs/behaviours/AudioPlaqueN3D.ts
+++ b/src/node3d/subs/behaviours/AudioPlaqueN3D.ts
@@ -7,6 +7,9 @@ import type { AutomationN3DConnectable } from "../../tools";
 import type { PointerInput } from "../../../xr/inputs/PointerInput";
 import { BoidSwarm } from "./steering/Boid";
 import { setupInstrumentControls, makeClusterButtons, OutputPulser, type ClusterButtons } from "./instrumentControls";
+import { Logger } from "../../../utils/logger";
+
+const log = Logger.get("AudioPlaque");
 
 // Le redimensionnement se fait désormais à DEUX MAINS (TwoPointerHoldBehaviour
 // au niveau de l'hôte) → plus de poignée de resize par instrument.
@@ -370,8 +373,8 @@ export class AudioPlaqueN3D implements Node3D {
             p.rotation.set(0, 0, 0);
             p.rotationQuaternion = Quaternion.Identity();
 
-            console.log(
-                "[AudioPlaque] Bounding box flattened",
+            log.debug(
+                "Bounding box flattened",
                 "\n  BB name        :", p.name,
                 "\n  BB rotation    : (0, 0, 0)  identity",
             );
@@ -387,8 +390,8 @@ export class AudioPlaqueN3D implements Node3D {
             `(${v.x.toFixed(3)}, ${v.y.toFixed(3)}, ${v.z.toFixed(3)})`;
 
         const spawnPos = context.getPosition();
-        console.log(
-            "[AudioPlaque] SPAWNED",
+        log.debug(
+            "SPAWNED",
             "\n  world position :", fmt(spawnPos.position),
             "\n  world rotation :", `(x:${spawnPos.rotation.x.toFixed(3)} y:${spawnPos.rotation.y.toFixed(3)} z:${spawnPos.rotation.z.toFixed(3)} w:${spawnPos.rotation.w.toFixed(3)})`,
             "\n  plaque local   :", fmt(gui.root.position),
@@ -483,7 +486,7 @@ export class AudioPlaqueN3D implements Node3D {
                 this.swarm.setEnabled(this.boidMode);
                 refreshToggleColor();
                 context.notifyStateChange("boidMode");
-                console.log("[AudioPlaque] Boid mode:", this.boidMode ? "ON" : "OFF",
+                log.debug("Boid mode:", this.boidMode ? "ON" : "OFF",
                     "  count:", this.boidCount);
             },
             release: () => {},
@@ -498,7 +501,7 @@ export class AudioPlaqueN3D implements Node3D {
                 this.boidCount = Math.min(BOID_MAX, this.boidCount + 1);
                 this.swarm.setCount(this.boidCount);
                 context.notifyStateChange("boidCount");
-                console.log("[AudioPlaque] Boid count:", this.boidCount);
+                log.debug("Boid count:", this.boidCount);
             },
             release: () => {},
         });
@@ -512,7 +515,7 @@ export class AudioPlaqueN3D implements Node3D {
                 this.boidCount = Math.max(0, this.boidCount - 1);
                 this.swarm.setCount(this.boidCount);
                 context.notifyStateChange("boidCount");
-                console.log("[AudioPlaque] Boid count:", this.boidCount);
+                log.debug("Boid count:", this.boidCount);
             },
             release: () => {},
         });
@@ -531,7 +534,7 @@ export class AudioPlaqueN3D implements Node3D {
                 { swatch: "🟢", name: "Green spheres (sides)", role: "Audio in / out (passes through)" },
                 { swatch: "🔵", name: "Top-left discs", role: "Boids: on/off, +, −" },
                 { swatch: "🌸", name: "Bottom row spheres", role: "Swarm metrics: centroid X/Y, dispersion, alignment, vorticity" },
-                { swatch: "✋", name: "Frame", role: "Two-handed grab = resize; top-right bin button = delete" },
+                { swatch: "✋", name: "Frame", role: "Two-handed grab = resize; bin button or vigorous shake = delete" },
             ],
             presets: {
                 "Solo":        { boidCount: 0 },
@@ -603,8 +606,8 @@ export class AudioPlaqueN3D implements Node3D {
                 const right  = gui.plaque.getDirection(new Vector3(1, 0, 0));
                 const up     = gui.plaque.getDirection(new Vector3(0, 1, 0));
                 const normal = gui.plaqueNormal();
-                console.log(
-                    "[AudioPlaque] GRAB DOWN",
+                log.debug(
+                    "GRAB DOWN",
                     "\n  controller     :", pointer.controller.side,
                     "\n  pointer.origin :", fmt(pointer.origin),
                     "\n  pointer.hit    :", pointer.hit,
@@ -619,8 +622,8 @@ export class AudioPlaqueN3D implements Node3D {
             },
             // onUp
             (pointer) => {
-                console.log(
-                    "[AudioPlaque] GRAB UP",
+                log.debug(
+                    "GRAB UP",
                     "\n  controller     :", pointer.controller.side,
                     "\n  final targetPos:", fmt(this.targetPos),
                     "\n  ball local pos :", fmt(gui.ballRoot.position),
@@ -632,8 +635,8 @@ export class AudioPlaqueN3D implements Node3D {
                 const t = pointerToTarget(pointer);
                 if (t) {
                     this.targetPos.copyFrom(t);
-                    console.log(
-                        "[AudioPlaque] GRAB MOVE",
+                    log.debug(
+                        "GRAB MOVE",
                         "\n  controller     :", pointer.controller.side,
                         "\n  pointer.origin :", fmt(pointer.origin),
                         "\n  pointer.target :", pointer.hit ? fmt(pointer.target) : "(no hit)",

--- a/src/node3d/subs/behaviours/FluidFieldN3D.ts
+++ b/src/node3d/subs/behaviours/FluidFieldN3D.ts
@@ -586,7 +586,7 @@ export class FluidFieldN3D implements Node3D {
                 { swatch: "🟢", name: "Top-left discs", role: "± boids (by 10)" },
                 { swatch: "🟩", name: "Green/red disc (right)", role: "Drone on/off (MIDI output)" },
                 { swatch: "🔴", name: "Bottom spheres", role: "Outputs: Disturbance, Curl, Swarm X/Y" },
-                { swatch: "✋", name: "Frame", role: "Two-handed grab = resize; top-right bin button = delete" },
+                { swatch: "✋", name: "Frame", role: "Two-handed grab = resize; bin button or vigorous shake = delete" },
             ],
             presets: FLUID_PRESETS,
             defaultPreset: "River",

--- a/src/node3d/subs/behaviours/Superformula3DN3D.ts
+++ b/src/node3d/subs/behaviours/Superformula3DN3D.ts
@@ -671,7 +671,7 @@ export class Superformula3DN3D implements Node3D {
                 { swatch: "🌸", name: "Pink knobs", role: "Ball X/Y/Z — aim at a surface point; centered = auto spiral" },
                 { swatch: "🔵", name: "Top-left discs", role: "3D boids: on/off, +, −" },
                 { swatch: "🟢", name: "Bottom spheres", role: "Automation outputs: posX/Y/Z, radius, speed, accel., curvature (+ boid metrics)" },
-                { swatch: "✋", name: "Cage", role: "Two-handed grab = resize; top-right bin button = delete" },
+                { swatch: "✋", name: "Cage", role: "Two-handed grab = resize; bin button or vigorous shake = delete" },
             ],
             presets: SF3D_PRESETS,
             defaultPreset: "Flower",

--- a/src/node3d/subs/behaviours/SuperformulaN3D.ts
+++ b/src/node3d/subs/behaviours/SuperformulaN3D.ts
@@ -636,7 +636,7 @@ export class SuperformulaN3D implements Node3D {
                 { swatch: "🟠", name: "Orange knobs (right)", role: "Ball scale and speed" },
                 { swatch: "🔵", name: "Top-left discs", role: "Boids: on/off, +, −" },
                 { swatch: "🟢", name: "Bottom spheres", role: "Automation outputs: posX/Y, radius, Δradius, speeds, accel., curvature (+ boids)" },
-                { swatch: "✋", name: "Frame", role: "Two-handed grab = resize; top-right bin button = delete" },
+                { swatch: "✋", name: "Frame", role: "Two-handed grab = resize; bin button or vigorous shake = delete" },
             ],
             presets: SF2D_PRESETS,
             defaultPreset: "5-point Star",

--- a/src/node3d/subs/behaviours/instrumentControls.ts
+++ b/src/node3d/subs/behaviours/instrumentControls.ts
@@ -56,6 +56,30 @@ export interface InstrumentControlsOpts {
 
 const clamp01 = (v: number) => Math.max(0, Math.min(1, v));
 
+// ─── Custom (user-saved) presets — persisted per instrument in localStorage ──
+//
+//   "Save current configuration" captures the live value of every tunable
+//   parameter as a named preset, stored under the instrument's title. They show
+//   up in the Presets menu (prefixed ★) on this and future sessions on the same
+//   device. Per-user / per-device by design (not synced across peers).
+
+type PresetMap = Record<string, Record<string, number>>;
+
+const customKey = (title: string) =>
+    `wamjam.presets.${title.replace(/[^a-z0-9]+/gi, "_").toLowerCase()}`;
+
+function loadCustomPresets(title: string): PresetMap {
+    try {
+        const raw = localStorage.getItem(customKey(title));
+        if (raw) return JSON.parse(raw) as PresetMap;
+    } catch { /* ignore */ }
+    return {};
+}
+
+function saveCustomPresets(title: string, presets: PresetMap): void {
+    try { localStorage.setItem(customKey(title), JSON.stringify(presets)); } catch { /* ignore */ }
+}
+
 export interface InstrumentControls {
     applyPreset(name: string): void;
     mutate(): void;
@@ -68,14 +92,53 @@ export function setupInstrumentControls(
     const byName = new Map(opts.params.map(p => [p.name, p]));
     const amount = opts.mutateAmount ?? 0.18;
 
+    // User-saved presets for this instrument, kept alongside the built-in ones.
+    let customPresets = loadCustomPresets(opts.title);
+
     const applyPreset = (name: string) => {
-        const preset = opts.presets[name];
+        const preset = opts.presets[name] ?? customPresets[name];
         if (!preset) return;
         for (const [pname, real] of Object.entries(preset)) {
             const p = byName.get(pname);
             if (p) p.setNorm(clamp01((real - p.min) / (p.max - p.min)));
         }
         context.showMessage(`Preset: ${name}`);
+    };
+
+    // Capture the current value of every tunable parameter as a new named preset.
+    const saveCurrentAsPreset = () => {
+        const snapshot: Record<string, number> = {};
+        for (const p of opts.params) snapshot[p.name] = p.min + p.getNorm() * (p.max - p.min);
+        let n = 1;
+        while (customPresets[`My Preset ${n}`]) n++;
+        const name = `My Preset ${n}`;
+        customPresets = { ...customPresets, [name]: snapshot };
+        saveCustomPresets(opts.title, customPresets);
+        context.showMessage(`Saved: ${name}`);
+    };
+
+    const clearCustomPresets = () => {
+        customPresets = {};
+        saveCustomPresets(opts.title, customPresets);
+        context.showMessage("Custom presets cleared");
+    };
+
+    // Build/refresh the Presets menu: built-in presets, then ★ custom ones,
+    // then the save / clear actions. Re-opened after save/clear so changes show.
+    const openPresetsMenu = () => {
+        const choices: { label: string; click?: () => void }[] = [];
+        for (const name of Object.keys(opts.presets)) {
+            choices.push({ label: name, click: () => applyPreset(name) });
+        }
+        for (const name of Object.keys(customPresets)) {
+            choices.push({ label: `★ ${name}`, click: () => applyPreset(name) });
+        }
+        choices.push({ label: "＋ Save current configuration", click: () => { saveCurrentAsPreset(); openPresetsMenu(); } });
+        if (Object.keys(customPresets).length > 0) {
+            choices.push({ label: "🗑 Delete my presets", click: () => { clearCustomPresets(); openPresetsMenu(); } });
+        }
+        choices.push({ label: "✖ Close", click: () => context.closeMenu() });
+        context.openMenu(choices);
     };
 
     const mutate = () => {
@@ -168,12 +231,7 @@ export function setupInstrumentControls(
         meshes: [opts.presetBtn],
         label: "Presets",
         color: new Color3(0.1, 0.75, 0.7),
-        press: () => {
-            context.openMenu(Object.keys(opts.presets).map(name => ({
-                label: name,
-                click: () => applyPreset(name),
-            })));
-        },
+        press: () => openPresetsMenu(),
         release: () => {},
     });
 

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,101 @@
+/**
+ * Small namespaced logger for WAM Jam Party.
+ *
+ * Goals
+ *  - One concise, tagged channel: `logger.info("[Shop] opened")` → `[Shop] opened`.
+ *  - A single global level so the console can be made quiet (default) or verbose
+ *    on demand, without editing call sites.
+ *  - A global filter (installConsoleFilter) that *also* gates the hundreds of
+ *    pre-existing raw `console.log/info/debug` calls scattered across the code,
+ *    so the console is clean by default. `console.warn` / `console.error` are
+ *    never suppressed.
+ *
+ * Runtime control (from the browser devtools console):
+ *    wamjamLog.setLevel("debug")   // show everything
+ *    wamjamLog.setLevel("warn")    // default — only warnings & errors
+ *    wamjamLog.getLevel()
+ * The choice is remembered in localStorage ("wamjam.logLevel").
+ */
+
+export type LogLevelName = "debug" | "info" | "warn" | "error" | "silent";
+
+const ORDER: Record<LogLevelName, number> = {
+    debug: 0, info: 1, warn: 2, error: 3, silent: 4,
+};
+
+const STORAGE_KEY = "wamjam.logLevel";
+const DEFAULT_LEVEL: LogLevelName = "warn";
+
+function readStoredLevel(): LogLevelName {
+    try {
+        const s = localStorage.getItem(STORAGE_KEY) as LogLevelName | null;
+        if (s && s in ORDER) return s;
+    } catch { /* localStorage unavailable */ }
+    return DEFAULT_LEVEL;
+}
+
+let currentLevel: number = ORDER[readStoredLevel()];
+let currentName: LogLevelName = readStoredLevel();
+
+export function setLogLevel(name: LogLevelName): void {
+    if (!(name in ORDER)) return;
+    currentName = name;
+    currentLevel = ORDER[name];
+    try { localStorage.setItem(STORAGE_KEY, name); } catch { /* ignore */ }
+}
+
+export function getLogLevel(): LogLevelName { return currentName; }
+
+/** True when messages at `level` should be shown given the current threshold. */
+function enabled(level: number): boolean { return level >= currentLevel && currentLevel < ORDER.silent; }
+
+/** A logger bound to a short tag, e.g. Logger.get("Shop"). */
+export class Logger {
+    private prefix: string;
+    private constructor(tag: string) { this.prefix = `[${tag}]`; }
+
+    static get(tag: string): Logger { return new Logger(tag); }
+
+    debug(...args: unknown[]): void { if (enabled(ORDER.debug)) originalConsole.debug(this.prefix, ...args); }
+    info(...args: unknown[]): void { if (enabled(ORDER.info)) originalConsole.info(this.prefix, ...args); }
+    warn(...args: unknown[]): void { if (enabled(ORDER.warn)) originalConsole.warn(this.prefix, ...args); }
+    error(...args: unknown[]): void { if (enabled(ORDER.error)) originalConsole.error(this.prefix, ...args); }
+}
+
+// Keep references to the real console methods so the logger keeps working even
+// after installConsoleFilter() has replaced the global ones.
+const originalConsole = {
+    log: console.log.bind(console),
+    info: console.info.bind(console),
+    debug: console.debug.bind(console),
+    warn: console.warn.bind(console),
+    error: console.error.bind(console),
+};
+
+let filterInstalled = false;
+
+/**
+ * Replace console.log / console.info / console.debug with level-gated versions
+ * so the existing raw logging across the codebase respects the global level.
+ * console.warn and console.error are left untouched. Idempotent.
+ */
+export function installConsoleFilter(): void {
+    if (filterInstalled) return;
+    filterInstalled = true;
+
+    console.log = (...args: unknown[]) => {
+        // Drop the wam3dgenerator memory-allocation spam (single bare numbers).
+        if (args.length === 1 && typeof args[0] === "number") return;
+        if (enabled(ORDER.info)) originalConsole.log(...args);
+    };
+    console.info = (...args: unknown[]) => { if (enabled(ORDER.info)) originalConsole.info(...args); };
+    console.debug = (...args: unknown[]) => { if (enabled(ORDER.debug)) originalConsole.debug(...args); };
+    // warn/error intentionally left as-is.
+
+    // Expose a tiny runtime control surface on window.
+    (globalThis as unknown as { wamjamLog?: unknown }).wamjamLog = {
+        setLevel: setLogLevel,
+        getLevel: getLogLevel,
+        levels: Object.keys(ORDER),
+    };
+}


### PR DESCRIPTION
## Overview

Follow-up to #56 (already merged). This PR adds a project-wide logging cleanup, a
shop search bar, user-saved instrument presets, and reinstates shake-to-delete
with stricter thresholds, plus a console-warning dedupe.

---

## Logging (new)

A namespaced logger with a single global verbosity switch, so the console is
clean by default but fully recoverable on demand.

**Files:** `src/utils/logger.ts`, wired once at startup in `src/index.ts`.

**What it does**
- `Logger.get("Tag")` returns a logger with `.debug() / .info() / .warn() / .error()`
  that prints `[Tag] message` for a consistent, traceable format.
- `installConsoleFilter()` replaces `console.log` / `console.info` / `console.debug`
  with level-gated versions. `console.warn` and `console.error` are never
  suppressed, so real problems always surface.
- Levels form a threshold: `debug(0) < info(1) < warn(2) < error(3) < silent(4)`.
  Anything below the current threshold is dropped.
- The default threshold is `warn`, so the hundreds of pre-existing raw
  `console.log` calls across the codebase are silenced in one move, without
  editing their call sites. The choice is persisted in
  `localStorage["wamjam.logLevel"]`.

**How to use it (runtime)**

From the browser devtools console:

```js
wamjamLog.setLevel("debug")   // show everything (debug + info + warn + error)
wamjamLog.setLevel("info")    // lifecycle logs, without per-frame debug spam
wamjamLog.setLevel("warn")    // default: warnings and errors only
wamjamLog.setLevel("error")   // errors only
wamjamLog.setLevel("silent")  // mute everything, including warnings/errors
wamjamLog.getLevel()          // read the current level
wamjamLog.levels              // list the available level names
```

The change takes effect immediately (no reload needed) and is remembered across
reloads via localStorage.

**How to use it (in code)**

```ts
import { Logger } from "../utils/logger";
const log = Logger.get("Shop");

log.debug("rebuilt grid", kinds.length);  // noisy / per-frame -> debug
log.info("session joined");                // lifecycle -> info
log.warn("MIDI output not wired");         // real problem -> always shows
log.error("failed to load model", err);    // always shows
```

Guidance: use `debug` for per-frame or high-frequency traces, `info` for one-shot
lifecycle events, and `warn` / `error` for genuine problems.

**Why it is better**
- Before, ~378 raw `console.*` calls always printed (e.g. the Audio Plaque logged
  on every controller move), making the console unusable.
- Now a single switch quiets the bulk instantly, the detail is recoverable on
  demand, real warnings/errors are never hidden, and new logs are consistently
  tagged. The Audio Plaque per-move logs were moved onto `log.debug`.
- Trade-off: `warn`/`error` always pass through by design. That is why the
  `EngineStore.LastCreatedScene` warning (a `console.warn`) is handled separately
  (see Console / warnings below).

---

## Shop search bar (new)

- A search field filters all kinds by label / kind / tag across every category as
  the user types, backed by an on-screen virtual keyboard (VR has no system
  keyboard for canvas inputs).
- Enter (hardware keyboard) or a Done button hides the keyboard while keeping the
  query, so results fill the panel; tapping the field reopens it. A clear button
  empties the query.
- Filtering is debounced so fast typing does not rebuild the grid on every
  keystroke.

## Saved presets (new)

- Every instrument's Presets menu gains "Save current configuration", which
  captures the current value of all tunable parameters as a named custom preset.
- Custom presets are listed with a star, can be deleted, and persist per
  instrument in `localStorage` (per device, not synced across peers). The menu
  also gains a Close entry.

## Shake-to-delete (reinstated, stricter)

- Reinstates shake-to-delete for nodes and connections with much stricter
  thresholds so items are not deleted by accident:
  - Node: swing amplitude 0.07 -> 0.13 m, reversals 10 -> 18, reset window
    700 -> 550 ms.
  - Connection: shake threshold 3 -> 5, sustain counter 10 -> 24.
- Instrument legends updated to mention both the delete button and shake.

## Console / warnings

- The `EngineStore.LastCreatedScene` warning, triggered many times per render by
  the third-party wam3dgenerator thumbnail loader (which we cannot fix upstream),
  is now deduplicated: it warns once, then suppresses the rest. A running count is
  kept on `SceneManager.lastCreatedSceneAccesses` for debugging.
